### PR TITLE
Simplify the pair monoid tests with notational conveniences.

### DIFF
--- a/src/Frexlet/Monoid.idr
+++ b/src/Frexlet/Monoid.idr
@@ -3,3 +3,4 @@ module Frexlet.Monoid
 import public Frexlet.Monoid.Theory
 import public Frexlet.Monoid.Frex
 import public Frexlet.Monoid.Nat
+import public Frexlet.Monoid.Pair

--- a/tests/frextests/monoids/PairTests.idr
+++ b/tests/frextests/monoids/PairTests.idr
@@ -1,21 +1,15 @@
 module PairTests
 
-import Data.Setoid.Pair
 import Frex
 import Frexlet.Monoid
-import Frexlet.Monoid.Frex.Construction
-import Frexlet.Monoid.Frex.Properties
-import Frexlet.Monoid.Frex.Structure
-import Frexlet.Monoid.Pair
-
-(*.) : Term Signature a -> Term Signature a -> Term Signature a
-(*.) x y = Call (MkOp Product) [x, y]
+import Frexlet.Monoid.Notation.Multiplicative
 
 assoc : {a, b, c : Setoid} -> Pair a (Pair b c) <~> Pair (Pair a b) c
-assoc = frexify (MonoidFrex MonoidPair _) [a, b, c]
-          (Dyn 0 *. (Dyn 1 *. Dyn 2), (Dyn 0 *. Dyn 1) *. Dyn 2)
+assoc = solve 3 (MonoidFrex MonoidPair _)
+         $ Dyn 0 .*. (Dyn 1 .*. Dyn 2) =-= (Dyn 0 .*. Dyn 1) .*. Dyn 2
 
 assoc4 : {a, b, c, d : Setoid} -> Pair (Pair a (Pair b c)) d <~> Pair a (Pair b (Pair c d))
-assoc4 = frexify (MonoidFrex MonoidPair _) [a, b, c, d]
-           ((Dyn 0 *. (Dyn 1 *. Dyn 2)) *. Dyn 3,
-            Dyn 0 *. (Dyn 1 *. (Dyn 2 *. Dyn 3)))
+assoc4 = solve 4 (MonoidFrex MonoidPair _)
+         $ (Dyn 0 .*. (Dyn 1 .*. Dyn 2)) .*. Dyn 3
+            =-=
+            Dyn 0 .*. (Dyn 1 .*. (Dyn 2 .*. Dyn 3))


### PR DESCRIPTION
- fewer imports
- `solve n` instead of `frexify ... [_,_,..._,]`
- standard `.*.` operator rather than `call (MkOp Product) ...`
- `=-=` instead of `,`