### PR TITLE
[ update ] Upcoming tightening of the parser

### DIFF
--- a/src/Data/Setoid/Definition.idr
+++ b/src/Data/Setoid/Definition.idr
@@ -104,22 +104,22 @@ record (~>) (A,B : Setoid) where
 
 public export
 mate : {b : Setoid} -> (a -> U b) -> (cast a ~> b)
-mate f = MkSetoidHomomorphism f \x,y, prf => reflect b (cong f prf)
+mate f = MkSetoidHomomorphism f $ \x,y, prf => reflect b (cong f prf)
 
 ||| Identity Setoid homomorphism
 public export
 id : (a : Setoid) -> a ~> a
-id a = MkSetoidHomomorphism Prelude.id \x, y, prf => prf
+id a = MkSetoidHomomorphism Prelude.id $ \x, y, prf => prf
 
 ||| Composition of Setoid homomorphisms
 public export
 (.) : {a,b,c : Setoid} -> b ~> c -> a ~> b -> a ~> c
-g . f = MkSetoidHomomorphism (H g . H f) \x,y,prf => g.homomorphic _ _ (f.homomorphic _ _ prf)
+g . f = MkSetoidHomomorphism (H g . H f) $ \x,y,prf => g.homomorphic _ _ (f.homomorphic _ _ prf)
 
 public export
 (~~>) : (a,b : Setoid) -> Setoid
 %unbound_implicits off
-(~~>) a b = MkSetoid (a ~> b)
+(~~>) a b = MkSetoid (a ~> b) $
   let 0 relation : (f, g : a ~> b) -> Type
       relation f g = (x : U a) -> b.equivalence.relation (f.H x) (g.H x)
   in MkEquivalence
@@ -177,7 +177,7 @@ IsoEquivalence = MkEquivalence (<~>) (\_ => refl) (\_,_ => sym) (\_,_,_ => trans
 ||| Instance of the more general coequaliser of two setoid morphisms.
 public export
 Quotient : (0 a : Type) -> {b : Setoid} -> (a -> U b) -> Setoid
-Quotient a {b} q = MkSetoid a
+Quotient a {b} q = MkSetoid a $
   let 0 Relation : a -> a -> Type
       Relation x y = b.equivalence.relation
         (q x)

--- a/src/Data/Setoid/Vect/Functional.idr
+++ b/src/Data/Setoid/Vect/Functional.idr
@@ -41,12 +41,12 @@ VectMap : {a, b : Setoid} -> (a ~~> b) ~> ((Functional.VectSetoid n a) ~~> (Func
 VectMap = MkSetoidHomomorphism
   (\f => MkSetoidHomomorphism
             (\xs => map f.H xs)
-            \xs, ys, prf, i  => CalcWith @{cast b} $
+            $ \xs, ys, prf, i  => CalcWith @{cast b} $
               |~ index i (map f.H xs)
               ~~ f.H (index i xs)     ...(indexNaturality _ _ _)
               <~ f.H (index i ys)     ...(f.homomorphic _ _ (prf i))
               ~~ index i (map f.H ys) ...(sym $ indexNaturality _ _ _))
-  \f,g,prf,xs,i => CalcWith @{cast b} $
+  $ \f,g,prf,xs,i => CalcWith @{cast b} $
     |~ index i (map f.H xs)
     ~~ f.H (index i xs) ...(indexNaturality _ _ _)
     <~ g.H (index i xs) ...(prf _)

--- a/src/Data/Vect/Extra1.idr
+++ b/src/Data/Vect/Extra1.idr
@@ -26,11 +26,11 @@ mapWithPosTabulate {n = S n} f x = Calc $
 
 export
 mapWithPosAsTabulate : {n : Nat} -> (f : Fin n -> a -> b) -> (xs : Vect n a) ->
-  mapWithPos f xs = tabulate \i => f i (index i xs)
+  mapWithPos f xs = tabulate (\i => f i (index i xs))
 mapWithPosAsTabulate f xs = vectorExtensionality _ _ $ \i => Calc $
   |~ index i (mapWithPos f xs)
-  ~~ f i (index i xs)                          ...(indexMapWithPos _ _ _)
-  ~~ index i (tabulate \j => f j (index j xs)) ...(sym $ indexTabulate _ _)
+  ~~ f i (index i xs)                            ...(indexMapWithPos _ _ _)
+  ~~ index i (tabulate $ \j => f j (index j xs)) ...(sym $ indexTabulate _ _)
 
 -- Currently not used
 ||| Version of `map` with runtime-irrelevant access to the current position

--- a/src/Frex/Algebra.idr
+++ b/src/Frex/Algebra.idr
@@ -84,7 +84,7 @@ Semantic (Algebra sig) (Op sig) where
 ||| @Sem : a semantic interpretation for each Sig-operation
 public export
 MkAlgebra : {0 Sig : Signature} -> (0 U : Type) -> (Sem : Sig `algebraOver'` U) -> Algebra Sig
-MkAlgebra u sem = MakeAlgebra u \f => uncurry (sem (snd f))
+MkAlgebra u sem = MakeAlgebra u $ \f => uncurry (sem (snd f))
 
 ||| Algebraic terms of this signature with variables in the given type
 public export
@@ -176,8 +176,8 @@ Functor (Term sig) where
 public export
 Applicative (Term sig) where
   pure = Done
-  (<*>) fs ts = (Free sig _).Sem fs \f =>
-                (Free sig _).Sem ts \x =>
+  (<*>) fs ts = (Free sig _).Sem fs $ \f =>
+                (Free sig _).Sem ts $ \x =>
                 Done (f x)
 
 public export
@@ -303,14 +303,14 @@ namespace Setoid
 
   public export
   id : (a : SetoidAlgebra sig) -> a ~> a
-  id a = MkSetoidHomomorphism (Setoid.Definition.id $ cast a)
+  id a = MkSetoidHomomorphism (Setoid.Definition.id $ cast a) $
           \f,xs => CalcWith @{cast a} $
           |~ a.Sem f xs
           ~~ a.Sem f (map id xs) ...(cong (a.Sem f) $ sym (mapId _))
 
   public export
   (.) : {a,b,c : SetoidAlgebra sig} -> b ~> c -> a ~> b -> a ~> c
-  g . f  = MkSetoidHomomorphism (H g . H f) \op, xs => CalcWith @{cast c} $
+  g . f  = MkSetoidHomomorphism (H g . H f) $ \op, xs => CalcWith @{cast c} $
     |~ g.H.H (f.H.H (a.Sem op xs))
     <~ g.H.H (b.Sem op (map (.H f.H) xs))        ...(g.H.homomorphic _ _ $ f.preserves op xs)
     <~ c.Sem op (map g.H.H (map f.H.H     xs))   ...(g.preserves op _)
@@ -523,7 +523,7 @@ namespace Signature
   public export
   OpTranslation : (castOp : {n : Nat} -> sig1.OpWithArity n -> sig2.OpWithArity n) -> sig1 ~> sig2
   OpTranslation castOp =
-     MkSignatureMorphism \op =>
+     MkSignatureMorphism $ \op =>
        Call (MkOp $ castOp op)
             (map Done Fin.range)
 

--- a/src/Frex/Free/Construction.idr
+++ b/src/Frex/Free/Construction.idr
@@ -279,7 +279,7 @@ FreeUPUnique pres x other extend1 extend2 t = CalcWith @{cast other.Model} $
   <~ other.Model.Sem t (extend2.H.H.H . (FreeData pres x).Env.H)  ...(bindCongruence t
        (extend1.H.H . (FreeData pres x).Env)
        (extend2.H.H . (FreeData pres x).Env)
-       \i => CalcWith @{cast other.Model} $
+       $ \i => CalcWith @{cast other.Model} $
          |~ extend1.H.H.H (Done i)
          <~ other.Env.H i          ...(extend1.preserves i)
          <~ extend2.H.H.H (Done i) ...(other.Model.equivalence.symmetric _ _ $

--- a/src/Frex/Free/Construction/ByFrex.idr
+++ b/src/Frex/Free/Construction/ByFrex.idr
@@ -31,7 +31,7 @@ public export
 (.OverVoid) : (model : Model pres) -> pres `ModelOver` (cast Void)
 model.OverVoid = MkModelOver
   { Model = model
-  , Env   = mate \case _ impossible
+  , Env   = mate $ \case _ impossible
   }
 
 public export

--- a/src/Frex/Frex/Construction.idr
+++ b/src/Frex/Frex/Construction.idr
@@ -35,7 +35,7 @@ EvaluationSig sig a = MkSignature $ EvaluationSigOperation sig a
 
 public export
 EvalEmbed : (sig : Signature) -> sig ~> EvaluationSig sig a
-EvalEmbed _ = OpTranslation \op => Op op
+EvalEmbed _ = OpTranslation Op
 
 public export
 data EvaluationAxiom : (sig : Signature) -> (axioms : Type) -> (a : Setoid) -> Type where
@@ -123,7 +123,7 @@ namespace Algebra
     ~~ tabulate (\i => bindTerm {a = a.algebra} (index i (castTerms (EvalEmbed sig {a = s}) ts)) env)
        ...(lemma {a = a.algebra} _ Prelude.id _)
     ~~ bindTerms {a = a.algebra} (castTerms (EvalEmbed sig {a = s}) ts) env
-       ...(vectorExtensionality _ _ \i => Calc $
+       ...(vectorExtensionality _ _ $ \i => Calc $
          -- Not my best moment, sorry
          |~ index i (Fin.tabulate _)
          ~~ _ ...(indexTabulate _ _)
@@ -180,7 +180,7 @@ freeAsExtension fs = MkExtension
         ~~ fs.Data.Model.Algebra.algebra.Semantics (MkOp $ Construction.Op op)
            (map (\i => fs.Data.Model.sem (Constant i)) xs)
            ...(cong (fs.Data.Model.Algebra.algebra.Semantics (MkOp $ Construction.Op op)) $
-               vectorExtensionality _ _ \i => Calc $
+               vectorExtensionality _ _ $ \i => Calc $
                -- Sorry, this will do for now
                |~ index i (bindTerms {a = fs.Data.Model.Algebra.algebra}
                     (map (\x => Call (MkOp (Constant x)) []) xs)
@@ -251,7 +251,7 @@ OverAlgebraNop : {pres : Presentation} -> {a : Model pres} -> {s : Setoid} ->
     (map (\x => Call (MkOp $ Constant x) []) xs)
     env
   === map other.Embed.H.H xs
-OverAlgebraNop other xs env = vectorExtensionality _ _ \i => Calc $
+OverAlgebraNop other xs env = vectorExtensionality _ _ $ \i => Calc $
  |~ index i (bindTerms {a = other.OverAlgebra.algebra}
                (map (\x => Call (MkOp $ Constant x) []) xs)
                env)

--- a/src/Frex/Model.idr
+++ b/src/Frex/Model.idr
@@ -79,7 +79,7 @@ parameters {0 sig : Signature} {a, b : SetoidAlgebra sig} (iso : a <~> b)
              ...((eval {a = b, x = cast x} t).homomorphic
                    (mate env)
                    (iso.Iso.Fwd . (iso.Iso.Bwd . mate env))
-                \i => (cast {to = Setoid} b ~~> cast b).equivalence.symmetric id_b' (id b).H
+                $ \i => (cast {to = Setoid} b ~~> cast b).equivalence.symmetric id_b' (id b).H
                          iso.Iso.Iso.FwdBwdId
                          (env i))
     <~ iso.Iso.Fwd.H (bindTerm {a = a.algebra} t (iso.Iso.Bwd.H . env))
@@ -203,7 +203,7 @@ public export
 (.cong) : {0 pres : Presentation} -> (a : Model pres) -> (0 n : Nat)
   -> (t : Term pres.signature (U a `Either` Fin n))
   -> (lhs, rhs : Vect n (U a))
-  -> HVect (tabulate \i => (cast a).equivalence.relation
+  -> HVect (tabulate $ \i => (cast a).equivalence.relation
        (index i lhs)
        (index i rhs))
   -> (cast a).equivalence.relation
@@ -213,7 +213,7 @@ public export
   = (Setoid.eval {x = cast $ U a `Either` Fin n} t).homomorphic
       (mate $ either Prelude.id $ flip index lhs)
       (mate $ either Prelude.id $ flip index rhs)
-      \case
+      $ \case
         Left  x => (cast a).equivalence.reflexive x
         Right i => replace {p = id}
               (indexTabulate _ _)

--- a/src/Frex/Powers/Abstract.idr
+++ b/src/Frex/Powers/Abstract.idr
@@ -15,14 +15,14 @@ parameters {pres : Presentation} {x : Setoid} {a : Model pres}
   public export
   id : (param : Parameterisation pres x a) -> param ~> param
   id param = MkParameterisationMorphism (id _)
-    \phi, i => (cast a).equivalence.reflexive _
+    $ \phi, i => (cast a).equivalence.reflexive _
 
   public export
   (.) : {param1, param2, param3 : Parameterisation pres x a} ->
     (param2 ~> param3) -> (param1 ~> param2) ->
     param1 ~> param3
   (.) {param1, param2, param3} u v = MkParameterisationMorphism (u.H . v.H)
-    \phi, i => CalcWith @{cast a} $
+    $ \phi, i => CalcWith @{cast a} $
       |~ (the _ $ param3.Eval.H i).H.H ((u.H . v.H).H.H phi)
       <~ (the _ $ param2.Eval.H i).H.H (v.H.H.H phi) ...(u.preserve _ _)
       <~ (the _ $ param1.Eval.H i).H.H phi           ...(v.preserve _ _)
@@ -40,7 +40,7 @@ parameters {pres : Presentation} {x : Setoid} {a : Model pres}
             (\x => let v = Prelude.cast {to = b ~> param.Model.Algebra} (sym iso)
                        u = (param.Eval.H x)
                    in u . v)
-            \p,q,prf,x => param.Eval.homomorphic
+            $ \p,q,prf,x => param.Eval.homomorphic
                       p q prf (iso.Iso.Bwd.H x)
       in MkParameterisation model eval
 
@@ -51,8 +51,8 @@ parameters {pres : Presentation} {x : Setoid} {a : Model pres}
     param ~> transportParameterisation param iso
   coherence param iso = MkParameterisationMorphism
     (cast iso)
-    \f,i => (the _ $ param.Eval.H i).H.homomorphic _ _
-                   $ iso .Iso.Iso.BwdFwdId f
+    $ \f,i => (the _ $ param.Eval.H i).H.homomorphic _ _
+                     $ iso .Iso.Iso.BwdFwdId f
 
   public export
   coherenceSym : {b : SetoidAlgebra pres.signature} ->
@@ -61,7 +61,7 @@ parameters {pres : Presentation} {x : Setoid} {a : Model pres}
     transportParameterisation param iso ~> param
   coherenceSym param iso = MkParameterisationMorphism
     (cast (sym iso))
-    \f,i => (cast a).equivalence.reflexive _
+    $ \f,i => (cast a).equivalence.reflexive _
 
 ||| Transport a power along an algebra isomorphism
 public export

--- a/src/Frex/Powers/Construction.idr
+++ b/src/Frex/Powers/Construction.idr
@@ -22,9 +22,9 @@ parameters {0 Sig : Signature} (X : Setoid) (A : SetoidAlgebra Sig)
   public export
   PowerAlgebra : Algebra Sig
   PowerAlgebra = MakeAlgebra (U PowerSetoid)
-      \f,phis =>
+      $ \f,phis =>
       MkSetoidHomomorphism (\i => (A).Sem f (map (\phi => phi.H i) phis))
-                           \u, v, prf => congruence A f _ _ \i =>
+                           $ \u, v, prf => congruence A f _ _ $ \i =>
                              CalcWith @{cast A} $
                              |~ index i (map (\phi => phi.H u) phis)
                              ~~ (index i phis).H u ...(indexNaturality _ _ _)
@@ -39,8 +39,8 @@ parameters {0 Sig : Signature} (X : Setoid) (A : SetoidAlgebra Sig)
         equiv = equivalence PowerSetoid
     in MkSetoidAlgebra PowerAlgebra
     equiv
-    \f, phis, psis, prf, this => (A).congruence f _ _
-      \i => CalcWith @{cast A} $
+    $ \f, phis, psis, prf, this => (A).congruence f _ _
+     $ \i => CalcWith @{cast A} $
       |~ index i (map (\phi => phi.H this) phis)
       ~~ (index i phis).H this ...(indexNaturality _ _ _)
       <~ (index i psis).H this ...(prf i this)
@@ -53,8 +53,8 @@ parameters {0 Sig : Signature} {X : Setoid} {A : SetoidAlgebra Sig}
   eval x = MkSetoidHomomorphism
     (MkSetoidHomomorphism (\phi => phi.H x)
                           (\phi, psi, prf => prf x))
-    \f, phis => A .equivalence.reflexive
-              $ ((X ~~> A).Sem f phis).H x
+    $ \f, phis => A .equivalence.reflexive
+               $ ((X ~~> A).Sem f phis).H x
 
   -- In fact, holds on the nose (i.e., with equality), but it's much
   -- easier to just use the existing homoPreservesSem (which also
@@ -62,8 +62,8 @@ parameters {0 Sig : Signature} {X : Setoid} {A : SetoidAlgebra Sig}
   public export
   pointwiseBind : (t : Term Sig y) -> (env : y -> U (X ~~> A)) -> (x : U X) ->
     A .equivalence.relation
-     (((X ~~> A).Sem t        env  ).H x)
-     (        A .Sem t \i => (env i).H x)
+     (((X ~~> A).Sem t          env  ).H x)
+     (        A .Sem t $ \i => (env i).H x)
   pointwiseBind t env x
     = homoPreservesSem (Frex.Powers.Construction.eval x) t env
 
@@ -74,7 +74,7 @@ namespace Model
     let X_to_A : SetoidAlgebra pres.signature
         X_to_A = x ~~> a.Algebra
     in MkModel X_to_A
-              \ax, env, x => CalcWith @{cast a} $
+              $ \ax, env, x => CalcWith @{cast a} $
     |~ (X_to_A .Sem (pres.axiom ax).lhs env).H x
     <~ a       .Sem (pres.axiom ax).lhs (\i => (env i).H x) ...(pointwiseBind _ _ _)
     <~ a       .Sem (pres.axiom ax).rhs (\i => (env i).H x) ...(a.Validate _ _)
@@ -91,7 +91,7 @@ a ^ x = MkPower
      (x ~~> a)
      $ MkSetoidHomomorphism
        eval
-       \x,y,x_eq_y,f => f.homomorphic _ _ x_eq_y)
+       $ \x,y,x_eq_y,f => f.homomorphic _ _ x_eq_y)
   $ IsUniversal
   { Exists = \other =>
       MkParameterisationMorphism
@@ -100,13 +100,13 @@ a ^ x = MkPower
                (\u => MkSetoidHomomorphism (\i =>
                   let f  = other.Eval.H i
                   in f.H.H u)
-                 \i,j,i_eq_j =>
+                 $ \i,j,i_eq_j =>
                    (other.Eval).homomorphic i j i_eq_j u)
-            \u,v,u_eq_v,i =>
+            $ \u,v,u_eq_v,i =>
               let phi : other.Model ~> a
                   phi = .H (.Eval other) i
               in  phi.H.homomorphic u v u_eq_v)
-          \op,env,i =>
+          $ \op,env,i =>
              let OtoA : (other.Model ~> a)
                         -- Not sure why we need the annotation --- idris bug?
                  OtoA = (the (U x -> U (other.Model ~~> a))
@@ -118,7 +118,7 @@ a ^ x = MkPower
              ~~ a.Sem op (map (\phi : (x ~> cast a) => phi.H i) (map _ env))
                               ...(cong (a.Sem op)
                                  $ sym $ mapFusion _ _ env))
-        \u,i => (cast a).equivalence.reflexive _
+        $ \u,i => (cast a).equivalence.reflexive _
   , Unique = \other, extend1,extend2,u,i => CalcWith @{cast a} $
       |~ (the _ $ extend1.H.H.H u).H i
       <~ (the _ $ other.Eval.H i).H.H u ...(extend1.preserve u i)

--- a/src/Frex/Powers/Fin.idr
+++ b/src/Frex/Powers/Fin.idr
@@ -24,7 +24,7 @@ FinPowerSetoid n a = VectSetoid n (cast a)
 
 public export
 FinPowerAlgebra : {0 sig : Signature} -> (n: Nat) -> (a: SetoidAlgebra sig) ->  Algebra sig
-FinPowerAlgebra n a = MakeAlgebra (U $ FinPowerSetoid n a) \op, xss =>
+FinPowerAlgebra n a = MakeAlgebra (U $ FinPowerSetoid n a) $ \op, xss =>
   map (a.algebra.Sem op) (transpose xss)
 
 public export
@@ -47,7 +47,7 @@ FinPowerSetoidAlgebra : {0 sig : Signature} -> (n: Nat) -> (a: SetoidAlgebra sig
 FinPowerSetoidAlgebra n a =
   let equiv : Equivalence (U $ FinPowerSetoid n a)
       equiv = (FinPowerSetoid n a).equivalence
-  in MkSetoidAlgebra (FinPowerAlgebra n a) equiv \op,xss,yss,prf,i =>
+  in MkSetoidAlgebra (FinPowerAlgebra n a) equiv $ \op,xss,yss,prf,i =>
   let lemma : (j : Fin $ arity op) ->
               a.equivalence.relation
                 (index j (map (index i) xss))
@@ -73,7 +73,7 @@ eval : {0 sig : Signature} -> {n : Nat} -> {a : SetoidAlgebra sig} ->
   (x : Fin n) -> (n `FinPowerSetoidAlgebra` a) ~> a
 eval x = MkSetoidHomomorphism
   (MkSetoidHomomorphism (index x)
-    \xs,ys,prf => prf x)
+    $ \xs,ys,prf => prf x)
    (indexHomomorphismLemma n a x)
 
 public export
@@ -92,16 +92,16 @@ representation =
   let fwd : Vect n (U a) -> (U (cast (Fin n) ~~> a))
       fwd xs = MkSetoidHomomorphism
                  (\x => index x xs)
-                 \x,y,x_eq_y => reflect (cast a)
+                 $ \x,y,x_eq_y => reflect (cast a)
                    (cong (flip index xs) x_eq_y)
   in MkIsomorphism
   { Iso = MkIsomorphism
       { Fwd = MkSetoidHomomorphism
                 fwd
-                \xs,ys,prf => prf
+                $ \xs,ys,prf => prf
       , Bwd = MkSetoidHomomorphism
                (\phi => tabulate phi.H)
-               \phis, psis, prf, i => CalcWith @{cast a} $
+               $ \phis, psis, prf, i => CalcWith @{cast a} $
                  |~ index i (tabulate phis.H)
                  ~~ phis.H i ...(indexTabulate _ _)
                  <~ psis.H i ...(prf i)

--- a/src/Frex/Presentation.idr
+++ b/src/Frex/Presentation.idr
@@ -75,7 +75,7 @@ namespace Presentation
 public export
 castEqHint : {auto castOp : sig1 ~> sig2} ->
    Cast (Equation sig1) (Equation sig2)
-castEqHint {castOp} = MkCast \eq =>
+castEqHint {castOp} = MkCast $ \eq =>
   MkEq
   { support = eq.support
   , lhs = cast eq.lhs

--- a/src/Frexlet/Monoid/Commutative/Coproduct.idr
+++ b/src/Frexlet/Monoid/Commutative/Coproduct.idr
@@ -74,9 +74,9 @@ CoprodAlgebraCongruence a b (MkOp Neutral)      xy1       xy2       prf
      , b.Algebra.congruence (MkOp Neutral) [] [] (\i => case i of {}))
 CoprodAlgebraCongruence a b op@(MkOp Product) [xy1,xy2] [uv1,uv2] prf
    = ( a.Algebra.congruence Plus [fst xy1, fst xy2] [fst uv1, fst uv2]
-         \case {0 => fst (prf 0); 1 => fst (prf 1)}
+         $ \case {0 => fst (prf 0); 1 => fst (prf 1)}
      , b.Algebra.congruence Plus [snd xy1, snd xy2] [snd uv1, snd uv2]
-         \case {0 => snd (prf 0); 1 => snd (prf 1)})
+         $ \case {0 => snd (prf 0); 1 => snd (prf 1)})
 
 public export
 CoprodAlgebra : (a, b : CommutativeMonoid) -> MonoidStructure
@@ -230,7 +230,7 @@ ExtenderIsHomomorphism a b other (MkOp Neutral) []
                     [other.Lft.preserves Zero []
                     ,other.Rgt.preserves Zero []])
     <~ O1 ...(other.Sink.validate (Mon LftNeutrality) [O1])
-ExtenderIsHomomorphism a b other (MkOp Product) [(x1,y1),(x2,y2)] 
+ExtenderIsHomomorphism a b other (MkOp Product) [(x1,y1),(x2,y2)]
   = let %hint otherNotation : Action1 Nat (U other.Sink)
         otherNotation = NatAction1 (other.Sink)
         %hint aNotation : Action1 Nat (U a)

--- a/src/Frexlet/Monoid/Commutative/Free.idr
+++ b/src/Frexlet/Monoid/Commutative/Free.idr
@@ -33,7 +33,7 @@ Model n = (Commutative.Nat.Additive ^ n).Data.Model
 ||| Monadic unit
 public export
 unit : (n : Nat) -> Fin n -> U (Model n)
-unit n i = Fin.tabulate \j => dirac i j
+unit n i = Fin.tabulate $ dirac i
 
 public export
 FreeCommutativeMonoidOver : (n : Nat) -> CommutativeMonoidTheory `ModelOver` (cast $ Fin n)
@@ -45,7 +45,7 @@ FreeCommutativeMonoidOver n =
 
 export
 FreeModelZeroRepresentation : (n : Nat) -> (Model n).sem Neutral = replicate n 0
-FreeModelZeroRepresentation  n = vectorExtensionality _ _ \i => Calc $
+FreeModelZeroRepresentation  n = vectorExtensionality _ _ $ \i => Calc $
   |~ index i (map (uncurry 0) (replicate n Vect.Nil))
   ~~ uncurry 0 (index i $ replicate n Vect.Nil) ...(indexNaturality _ _ _)
   ~~ 0                                          ...(Refl)
@@ -120,7 +120,7 @@ lemma2 : (n : Nat) -> (i : Fin n) -> (xs : Vect n Nat) ->
       %hint
       notation' : Action1 Nat (U $ Commutative.Nat.Additive)
       notation' = NatAction1 Additive
-  in map (index i) (tabulate \j => (index j xs) *. (unit n j))
+  in map (index i) (tabulate $ \j => (index j xs) *. (unit n j))
   =  tabulate (\j => (dirac i j) *. (index j xs))
 lemma2 n i xs =
   let %hint
@@ -130,9 +130,9 @@ lemma2 n i xs =
       notation' : Action1 Nat (U $ Commutative.Nat.Additive)
       notation' = NatAction1 Additive
   in Calc $
-        |~ map (index i) (tabulate \j => (index j xs) *. (unit n j))
+        |~ map (index i) (tabulate $ \j => (index j xs) *. (unit n j))
         ~~ tabulate (\j => (index i $ (index j xs) *. (unit n j))) ...(sym $ mapTabulate (index i)
-                                                                      \j => (index j xs) *. (unit n j))
+                                                                      $ \j => (index j xs) *. (unit n j))
         ~~ tabulate (\j => (dirac i j) *. (index j xs)) ...(tabulateExtensional _ _
                                                            $ \j => lemma1 n i j xs)
 
@@ -142,7 +142,7 @@ normalForm : (n : Nat) -> (xs : U (Model n)) ->
   let %hint
       notation : Action1 Nat (U $ Model n)
       notation = NatAction1 (Model n)
-  in (Model n).sum (tabulate \i => (index i xs) *. (unit n i)) = xs
+  in (Model n).sum (tabulate $ \i => (index i xs) *. (unit n i)) = xs
 normalForm n xs = vectorExtensionality _ _ $ \i =>
   let %hint
       notation : Action1 Nat (U $ Model n)
@@ -151,12 +151,12 @@ normalForm n xs = vectorExtensionality _ _ $ \i =>
       notation' : Action1 Nat (U $ Commutative.Nat.Additive)
       notation' = NatAction1 Additive
   in Calc $
-  |~ index i ((Model n).sum (tabulate \i => (index i xs) *. (unit n i)))
-  ~~ (Additive).sum (map (index i) (tabulate \i => (index i xs) *. (unit n i)))
-                                                                 ...(pointwiseSum n _ _)
-  ~~ (Additive).sum (tabulate \j => (dirac i j) *. (index j xs)) ...(cong (Additive).sum $
-                                                                    lemma2 n i xs)
-  ~~ index i xs                                                  ...(convolveDirac Additive _ _)
+  |~ index i ((Model n).sum (tabulate $ \i => (index i xs) *. (unit n i)))
+  ~~ (Additive).sum (map (index i) (tabulate $ \i => (index i xs) *. (unit n i)))
+                                                                   ...(pointwiseSum n _ _)
+  ~~ (Additive).sum (tabulate $ \j => (dirac i j) *. (index j xs)) ...(cong (Additive).sum $
+                                                                      lemma2 n i xs)
+  ~~ index i xs                                                    ...(convolveDirac Additive _ _)
 
 public export
 FreeExtenderFunction : ExtenderFunction (FreeCommutativeMonoidOver n)
@@ -214,11 +214,11 @@ extenderPreservesPlus other [xs,ys] =
       h = FreeExtenderFunction other
 
       lemma2 : (j : Fin n) ->
-        other.Model.rel (index j $ tabulate \i => (index i $ xs .+. ys) *. other.Env.H i)
-                        (index j $ tabulate \i => (index i xs) *. other.Env.H i
-                                              .+. (index i ys) *. other.Env.H i)
+        other.Model.rel (index j $ tabulate $ \i => (index i $ xs .+. ys) *. other.Env.H i)
+                        (index j $ tabulate $ \i => (index i xs) *. other.Env.H i
+                                                .+. (index i ys) *. other.Env.H i)
       lemma2 j = CalcWith @{cast other.Model} $
-        |~ index j (tabulate \i => (index i $ xs .+. ys) *. other.Env.H i)
+        |~ index j (tabulate $ \i => (index i $ xs .+. ys) *. other.Env.H i)
         ~~ index j (xs .+. ys) *. other.Env.H j           ...(indexTabulate _ _)
         ~~ ((index j xs) + (index j ys)) *. other.Env.H j
             ...(cong (\u : Nat => u *. (other.Env.H j)) $
@@ -226,19 +226,19 @@ extenderPreservesPlus other [xs,ys] =
                         j).preserves Plus [xs,ys])
         <~  (index j xs) *. other.Env.H j  .+.  (index j ys) *. other.Env.H j
             ...(multDistributesOverPlusLeft other.Model _ _ _)
-        ~~ index j (tabulate \i => (index i xs) *. other.Env.H i
-                                              .+. (index i ys) *. other.Env.H i)
+        ~~ index j (tabulate $ \i => (index i xs) *. other.Env.H i
+                                                .+. (index i ys) *. other.Env.H i)
             ...(sym $ indexTabulate _ _)
   in CalcWith @{cast other.Model} $
   |~ h (xs .+. ys)
   ~~ other.Model.sum (mapWithPos (\i, k => k *. other.Env.H i) (xs .+. ys)) ...(Refl)
-  ~~ other.Model.sum (tabulate \i => (index i $ xs .+. ys) *. other.Env.H i)
+  ~~ other.Model.sum (tabulate $ \i => (index i $ xs .+. ys) *. other.Env.H i)
       ...(cong other.Model.sum $ mapWithPosAsTabulate _ _)
-  <~ other.Model.sum (tabulate \i =>  (index i xs) *. other.Env.H i
+  <~ other.Model.sum (tabulate $ \i =>  (index i xs) *. other.Env.H i
                                   .+. (index i ys) *. other.Env.H i)
                    ...(other.Model.sum.homomorphic _ _ (\i => lemma2 i))
-  <~ other.Model.sum (tabulate \i => (index i xs) *. other.Env.H i) .+.
-     other.Model.sum (tabulate \i => (index i ys) *. other.Env.H i)
+  <~ other.Model.sum (tabulate $ \i => (index i xs) *. other.Env.H i) .+.
+     other.Model.sum (tabulate $ \i => (index i ys) *. other.Env.H i)
                    ...(sumCommutative other.Model _ _)
   <~ h xs .+. h ys ...(other.Model.cong 2 (Dyn 0 .+. Dyn 1) [_,_] [_,_]
                        [ Data.Setoid.Definition.reflect (cast other.Model) $ sym $
@@ -271,10 +271,10 @@ extenderIsMorphism {n} other i =
   in CalcWith @{cast other.Model} $
   |~ h (unit n i)
   ~~ other.Model.sum (mapWithPos (\j,k => k *. other.Env.H j) (unit n i)) ...(Refl)
-  ~~ other.Model.sum (tabulate \j => (index j (unit n i)) *. other.Env.H j)
+  ~~ other.Model.sum (tabulate $ \j => (index j (unit n i)) *. other.Env.H j)
     ...(cong other.Model.sum $ mapWithPosAsTabulate _ _)
-  ~~ other.Model.sum (tabulate \j => (dirac i j) *. other.Env.H j)
-    ...(cong other.Model.sum $ tabulateExtensional _ _ \j => cong (\u : Nat => u *. other.Env.H j)
+  ~~ other.Model.sum (tabulate $ \j => (dirac i j) *. other.Env.H j)
+    ...(cong other.Model.sum $ tabulateExtensional _ _ $ \j => cong (\u : Nat => u *. other.Env.H j)
        $indexTabulate (dirac i) j)
   <~ other.Env.H i ...(convolveDirac other.Model _ _)
 
@@ -299,17 +299,17 @@ uniqueExtender other extend xs =
       notation' = NatAction1 (Model n)
   in CalcWith @{cast other.Model} $
   |~ extend.H.H.H xs
-  ~~ extend.H.H.H ((Model n).sum (tabulate \i => (index i xs) *. unit n i))
+  ~~ extend.H.H.H ((Model n).sum (tabulate $ \i => (index i xs) *. unit n i))
         ...(cong extend.H.H.H $ sym $ normalForm n xs)
-  <~ other.Model.sum (map extend.H.H.H $ (tabulate \i => (index i xs) *. unit n i))
+  <~ other.Model.sum (map extend.H.H.H $ (tabulate $ \i => (index i xs) *. unit n i))
         ...(sumPreservation (Model n) other.Model extend.H _)
-  ~~ other.Model.sum (tabulate \i => extend.H.H.H ((index i xs) *. unit n i))
+  ~~ other.Model.sum (tabulate $ \i => extend.H.H.H ((index i xs) *. unit n i))
         ...(cong other.Model.sum $ sym $ mapTabulate _ _)
-  <~ other.Model.sum (tabulate \i => (index i xs) *. extend.H.H.H (unit n i))
-        ...(sumTabulateExtensional other.Model _ _ \i =>
+  <~ other.Model.sum (tabulate $ \i => (index i xs) *. extend.H.H.H (unit n i))
+        ...(sumTabulateExtensional other.Model _ _ $ \i =>
             multPreservation (Model n) other.Model extend.H (index i xs) (unit n i))
-  <~ other.Model.sum (tabulate \i => (index i xs) *. other.Env.H i)
-        ...(sumTabulateExtensional other.Model _ _ \i =>
+  <~ other.Model.sum (tabulate $ \i => (index i xs) *. other.Env.H i)
+        ...(sumTabulateExtensional other.Model _ _ $ \i =>
             multIsHomomorphism other.Model _ _ _ $
             extend.preserves i)
   ~~ FreeExtenderFunction other xs ...(cong other.Model.sum $ sym $

--- a/src/Frexlet/Monoid/Commutative/Nat.idr
+++ b/src/Frexlet/Monoid/Commutative/Nat.idr
@@ -21,13 +21,13 @@ import Syntax.PreorderReasoning
 public export
 Additive : CommutativeMonoid
 Additive
-  = MkCommutativeMonoid Monoid.Nat.Additive       \env => plusCommutative _ _
+  = MkCommutativeMonoid Monoid.Nat.Additive $ \env => plusCommutative _ _
 
 ||| Multiplicative monoid structure over the natural numbers
 public export
 Multiplicative : CommutativeMonoid
 Multiplicative
-  = MkCommutativeMonoid Monoid.Nat.Multiplicative \env => multCommutative _ _
+  = MkCommutativeMonoid Monoid.Nat.Multiplicative $ \env => multCommutative _ _
 
 public export
 multActionNat : (m, n : Nat) ->

--- a/src/Frexlet/Monoid/Commutative/NatSemiLinear/Dirac.idr
+++ b/src/Frexlet/Monoid/Commutative/NatSemiLinear/Dirac.idr
@@ -56,14 +56,14 @@ convolveDirac : (a : CommutativeMonoid) -> {n : Nat} ->
       notation : Action1 Nat (U a)
       notation = NatAction1 a
   in (f : Fin n -> U a) -> (i : Fin n) ->
-   a.rel (a.sum $ tabulate \j => (dirac i j ) *. f j)
+   a.rel (a.sum $ tabulate $ \j => (dirac i j ) *. f j)
          (f i)
 convolveDirac a f i =
   let %hint
       notation : Action1 Nat (U a)
       notation = NatAction1 a
       xs : Vect n (U a)
-      xs = tabulate \j => (dirac i j) *. f j
+      xs = tabulate $ \j => (dirac i j) *. f j
       pointMass : (j : Fin n) ->
         (i = j) `Either` (a.rel (index j xs)
                                 O1)

--- a/src/Frexlet/Monoid/Commutative/NatSemiLinear/Sum.idr
+++ b/src/Frexlet/Monoid/Commutative/NatSemiLinear/Sum.idr
@@ -149,7 +149,7 @@ sumCommutative : {n : Nat} -> (a : CommutativeMonoid) -> (f,g : Fin n -> U a) ->
   let %hint
       notation : Action1 Nat (U a)
       notation = NatAction1 a
-  in a.rel (a.sum $ tabulate \i => f i .+. g i)
+  in a.rel (a.sum $ tabulate $ \i => f i .+. g i)
            (a.sum (tabulate f) .+. a.sum (tabulate g))
 sumCommutative {n = 0} a f g =
   let %hint
@@ -164,8 +164,8 @@ sumCommutative {n = S n} a f g =
       notation : Action1 Nat (U a)
       notation = NatAction1 a
   in CalcWith @{cast a} $
-  |~ a.sum (tabulate \i => f i .+. g i)
-  ~~ (f 0 .+. g 0) .+. a.sum (tabulate \i => (f . FS) i .+. (g . FS) i)
+  |~ a.sum (tabulate $ \i => f i .+. g i)
+  ~~ (f 0 .+. g 0) .+. a.sum (tabulate $ \i => (f . FS) i .+. (g . FS) i)
               ...(Refl)
   <~ (f 0 .+. g 0) .+. (a.sum (tabulate $ f . FS) .+. a.sum (tabulate $ g . FS))
               ...(a.cong 1 (Sta (f 0 .+. g 0) :+: Dyn 0) [_] [_]
@@ -204,4 +204,3 @@ sumPreservation a b h (x :: xs) =
   <~ h.H.H x .+. b.sum (map h.H.H xs) ...(b.cong 1 (Sta _ .+. Dyn 0) [_] [_]
                                           [sumPreservation _ _ _ _])
   ~~ b.sum (map h.H.H (x :: xs))      ...(Refl)
-

--- a/src/Frexlet/Monoid/Commutative/Theory.idr
+++ b/src/Frexlet/Monoid/Commutative/Theory.idr
@@ -14,7 +14,7 @@ data Axiom
 
 public export
 CommutativeMonoidTheory : Presentation
-CommutativeMonoidTheory = MkPresentation Theory.Signature Commutative.Theory.Axiom \case
+CommutativeMonoidTheory = MkPresentation Theory.Signature Commutative.Theory.Axiom $ \case
     Mon ax => (MonoidTheory).axiom ax
     Commutativity => commutativity Product
 

--- a/src/Frexlet/Monoid/Involutive/Involution.idr
+++ b/src/Frexlet/Monoid/Involutive/Involution.idr
@@ -42,7 +42,7 @@ namespace Algebra
     , equivalence = a.equivalence
     , congruence = \case
         MkOp Neutral => \x,y,prf => a.congruence Unit x y prf
-        MkOp Product => \[x1,x2],[y1,y2],prf => a.congruence Prod [x2,x1] [y2,y1] \case
+        MkOp Product => \[x1,x2],[y1,y2],prf => a.congruence Prod [x2,x1] [y2,y1] $ \case
           0 => prf 1
           1 => prf 0
     }
@@ -58,7 +58,7 @@ public export
       LftNeutrality => a.Validate RgtNeutrality
       RgtNeutrality => a.Validate LftNeutrality
       Associativity => \env => a.equivalence.symmetric _ _
-                         $ a.Validate Associativity \case
+                         $ a.Validate Associativity $ \case
                          0 => env 2
                          1 => env 1
                          2 => env 0

--- a/src/Frexlet/Monoid/Involutive/Theory.idr
+++ b/src/Frexlet/Monoid/Involutive/Theory.idr
@@ -30,8 +30,9 @@ namespace Axiom
 
 public export
 InvolutiveMonoidTheory : Presentation
-InvolutiveMonoidTheory = MkPresentation Involutive.Theory.Signature Involutive.Theory.Axiom.Axiom
-  \case
+InvolutiveMonoidTheory
+  = MkPresentation Involutive.Theory.Signature Involutive.Theory.Axiom.Axiom
+  $ \case
     Mon ax => cast ((MonoidTheory).axiom ax)
     Involutivity       => involutivity       Involution
     Antidistributivity => antidistributivity Involution (Mono Product)

--- a/src/Frexlet/Monoid/Theory.idr
+++ b/src/Frexlet/Monoid/Theory.idr
@@ -22,7 +22,7 @@ data Axiom
 
 public export
 MonoidTheory : Presentation
-MonoidTheory = MkPresentation Theory.Signature Theory.Axiom \case
+MonoidTheory = MkPresentation Theory.Signature Theory.Axiom $ \case
     LftNeutrality => lftNeutrality Neutral Product
     RgtNeutrality => rgtNeutrality Neutral Product
     Associativity => associativity Product


### PR DESCRIPTION
https://github.com/idris-lang/Idris2/pull/1711 makes the parser
stricter and in exchange returns better error messages in some
cases that seem to trip beginners over often.

We are particularly hit by the fact that we can't have dangling
let / rewrite / lam (that last one is the big one) as the last
argument of an application.

The fix is easy: insert many, many `$`.