### PR TITLE
Disambiguate List literal

### DIFF
--- a/src/Frex/Free/Construction/Idris.idr
+++ b/src/Frex/Free/Construction/Idris.idr
@@ -153,7 +153,7 @@ idris printer is proofs = with [List.(++), Prelude.(.)] show $ vcat
     hidingList =
       let nms = flip List.mapMaybe (enumerate {a = pres .Axiom}) $ \ ax =>
                   do let nm = uncapitalise (show @{printer.axiomShow} ax)
-                     guard $ Prelude.elem nm
+                     guard $ elem nm $ the (List String)
                        [ "lftNeutrality"
                        , "rgtNeutrality"
                        , "associativity"


### PR DESCRIPTION
PR https://github.com/idris-lang/Idris2/pull/2294 abstracts `Prelude.elem` from `List` to `Foldable`, requiring additional disambiguation here.