### PR TITLE
Use Data.Vect.Quantifiers.All from base instead of Data.HVect from contrib.

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Install Idris2
         if: steps.cache-idris2.outputs.cache-hit != 'true'
         run: |
-          # git clone https://github.com/idris-lang/idris2
           git clone https://github.com/mattpolzin/idris2
           cd idris2
           git checkout ${{ env.IDRIS2_COMMIT }}

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Install Idris2
         if: steps.cache-idris2.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/idris-lang/idris2
+          # git clone https://github.com/idris-lang/idris2
+          git clone https://github.com/mattpolzin/idris2
           cd idris2
           git checkout ${{ env.IDRIS2_COMMIT }}
           make bootstrap && make install

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -12,7 +12,7 @@ on:
 ########################################################################
 
 env:
-  IDRIS2_COMMIT: 22b98f231ea8ba6682f9828dcbb18f4c0809921b
+  IDRIS2_COMMIT: 2a05023e398e667edfd42901b8988ee0a217205a
   SCHEME: scheme
 
 jobs:

--- a/src/Data/Setoid/Vect/Functional.idr
+++ b/src/Data/Setoid/Vect/Functional.idr
@@ -4,7 +4,7 @@ module Data.Setoid.Vect.Functional
 import Data.Setoid.Definition
 
 import Data.Vect
-import Data.HVect
+import Data.Vect.Quantifiers
 import Data.Vect.Properties
 import Data.Setoid.Vect.Inductive
 import Control.Order

--- a/src/Data/Setoid/Vect/Inductive.idr
+++ b/src/Data/Setoid/Vect/Inductive.idr
@@ -4,7 +4,7 @@ module Data.Setoid.Vect.Inductive
 import Data.Setoid.Definition
 
 import Data.Vect
-import Data.HVect
+import Data.Vect.Quantifiers
 import Data.Vect.Properties
 
 %default total

--- a/src/Frex/Model.idr
+++ b/src/Frex/Model.idr
@@ -8,7 +8,7 @@ import Frex.Presentation
 import Data.Setoid
 import Data.Vect
 import Data.Vect.Extra
-import Data.HVect
+import Data.Vect.Quantifiers
 import Data.Fin
 
 infix 1 =|

--- a/src/Frexlet/Monoid/Commutative/Notation/Core.idr
+++ b/src/Frexlet/Monoid/Commutative/Notation/Core.idr
@@ -6,7 +6,7 @@ import Frexlet.Monoid.Commutative.Theory
 
 import public Notation
 import public Notation.Action
-import public Data.HVect
+import public Data.Vect.Quantifiers
 import public Frex.Free
 import public Frex.Free.Construction
 

--- a/src/Notation/Action.idr
+++ b/src/Notation/Action.idr
@@ -1,6 +1,6 @@
 module Notation.Action
 
-import public Data.HVect
+import public Data.Vect.Quantifiers
 import public Data.Fun.Extra
 
 import public Notation
@@ -8,14 +8,6 @@ import public Notation.Additive
 import public Notation.Multiplicative
 
 %default total
-
-public export
-head : HVect (ty :: tys) -> ty
-head (x :: xs) = x
-
-public export
-tail : HVect (ty :: tys) -> HVect tys
-tail (x :: xs) = xs
 
 public export
 Action1 : (a,b : Type) -> Type

--- a/src/Notation/Additive.idr
+++ b/src/Notation/Additive.idr
@@ -2,7 +2,7 @@ module Notation.Additive
 
 import Notation
 
-import public Data.HVect
+import public Data.Vect.Quantifiers
 import public Data.Fun.Extra
 
 %default total

--- a/src/Notation/Multiplicative.idr
+++ b/src/Notation/Multiplicative.idr
@@ -2,7 +2,7 @@ module Notation.Multiplicative
 
 import Notation
 
-import public Data.HVect
+import public Data.Vect.Quantifiers
 import public Data.Fun.Extra
 
 %default total


### PR DESCRIPTION
This pairs with https://github.com/idris-lang/Idris2/pull/3191 to switch to base's `Data.Vect.Quantifiers.All.HVect` (an alias for `All id`) instead of using `Data.HVect` from contrib.

That Pr is needed before this PR will build at least for its public expose change on `head`/`tail` functions if not for other functions it ports from `contrib` into `base`. To show compatibility, I changed this repo's `IDRIS2_COMMIT` in CI to point at a merge of Idris 2's main branch and the aforementioned PR.