### PR TITLE
[ fix ] Fix coverage issue

### DIFF
--- a/src/Frexlet/Monoid/Frex/Structure.idr
+++ b/src/Frexlet/Monoid/Frex/Structure.idr
@@ -159,8 +159,10 @@ MultHomomorphism a s (i, ConsUlt i1 x is) (j,ConsUlt j1 y js)
   = ( a.cong 2 (Dyn 0 .*. Dyn 1) [_,_] [_,_] [i_eq_j, i1_eq_i2]
     , x_eq_y
     ) :: is_eq_js
-MultHomomorphism _ _ (_, Ultimate _) (_, ConsUlt _ _ _) (MkAnd _ _) impossible
-MultHomomorphism _ _ (_, ConsUlt _ _ _) (_, Ultimate _) (MkAnd _ _) impossible
+MultHomomorphism _ _ (_, Ultimate _) (_, ConsUlt _ _ _) x with (x)
+  _ | MkAnd _ _ impossible
+MultHomomorphism _ _ (_, ConsUlt _ _ _) (_, Ultimate _) x with (x)
+  _ | MkAnd _ _ impossible
 
 public export
 AppendHomomorphismProperty : (a : Monoid) -> (x : Setoid) ->

--- a/src/Frexlet/Monoid/Frex/Structure.idr
+++ b/src/Frexlet/Monoid/Frex/Structure.idr
@@ -145,6 +145,12 @@ UltListSetoid pen ult = MkSetoid (UltList (U pen) (U ult)) $ MkEquivalence
   , transitive = UltListTransitive pen ult
   }
 
+Uninhabited (UltListEquality penRel ultRel (Ultimate i) (ConsUlt j1 y js)) where
+  uninhabited _ impossible
+
+Uninhabited (UltListEquality penRel ultRel (ConsUlt i1 x is) (Ultimate j)) where
+  uninhabited _ impossible
+
 public export
 MultHomomorphism : (a : Monoid) -> (s : Setoid) ->
   SetoidHomomorphism
@@ -159,10 +165,8 @@ MultHomomorphism a s (i, ConsUlt i1 x is) (j,ConsUlt j1 y js)
   = ( a.cong 2 (Dyn 0 .*. Dyn 1) [_,_] [_,_] [i_eq_j, i1_eq_i2]
     , x_eq_y
     ) :: is_eq_js
-MultHomomorphism _ _ (_, Ultimate _) (_, ConsUlt _ _ _) x with (x)
-  _ | MkAnd _ _ impossible
-MultHomomorphism _ _ (_, ConsUlt _ _ _) (_, Ultimate _) x with (x)
-  _ | MkAnd _ _ impossible
+MultHomomorphism _ _ (_, Ultimate _) (_, ConsUlt _ _ _) (MkAnd _ eq) = absurd eq
+MultHomomorphism _ _ (_, ConsUlt _ _ _) (_, Ultimate _) (MkAnd _ eq) = absurd eq
 
 public export
 AppendHomomorphismProperty : (a : Monoid) -> (x : Setoid) ->


### PR DESCRIPTION
The function `MultHomomorphism` currently relies on a bug in Idris (idris-lang/Idris2#2250) for coverage. In that issue a `(,)` or `()` on the LHS of an impossible clause is treated as a pattern var (wildcard) during coverage checking.  If we explicitly put `MkPair` in `MultHomomorphism`, the coverage check fails.  The PR idris-lang/Idris2#3396 fixes idris-lang/Idris2#2250 by resolving the ambiguity as `MkPair` instead of inserting a pattern variable and causes frex to fail to build. So we should update frex before that PR is merged.  

The Pair/MkPair ambiguity in the current frex code is short-circuiting coverage checking. This coverage check failure can be reproduced with the current Idris by writing `MkPair` for the pairs in the two impossible clauses of `MultHomomorphism` to get:
```
MultHomomorphism is not covering.

Missing cases:
    MultHomomorphism _ _ (_, Ultimate _) (_, ConsUlt _ _ _) _
    MultHomomorphism _ _ (_, ConsUlt _ _ _) (_, Ultimate _) _
```

The `MultHomomorphism` function is indeed covering - Idris accepts it as such when there are holes on the RHS instead of `impossible`.  The issue goes away if the `MkAnd` match is pushed down into a `with` clause, so that's what I do in this patch. There probably is a bug in coverage checking with respect to impossible clauses here, but I haven't tracked it down and the workaround seems sufficient.
